### PR TITLE
fix(v1.0.1): wrap ZodError as readable validation error + document enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## [1.0.1] — 2026-04-26
+
+### Fixed
+- Zod enum errors are no longer swallowed as opaque "Internal error". The central CallTool handler in `src/server.ts` now catches `ZodError` (both at input parsing and inside tool handlers) and returns a readable `Validation error: <path>: <message>; ...` payload via `isError: true`. Mirrors the `@vantageos/mcp-frameworks@1.0.1` fix — same root cause.
+- All `z.enum(...)` schemas now carry an explicit `.describe()` listing every enum value (12 roles, 10 personas, 16 frameworks, 5 role categories, 4 persona axes, 3 composition formats, 2 locales). Models calling the server via MCP can now pick valid IDs without round-tripping through `list_roles` / `list_personas` for trivial choices.
+
+### Tests
+- New `tests/unit/zod-error-handling.test.ts` exercises the Validation-error wrap path on `compose_agent` (invalid `role_id`) and `suggest_composition` (`goal` shorter than 20 chars), plus a positive control. 35/35 unit + integration tests green; 15/15 evals green.
+
+### Notes
+- Pure functional fix, no data layer change: 12 roles + 10 personas + 16 framework-steps stay byte-for-byte identical to v1.0.0.
+
+[1.0.1]: https://github.com/elpiarthera/vantage-agent-composer-mcp/releases/tag/v1.0.1
+
 ## [1.0.0] — 2026-04-26
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vantageos/mcp-agent-composer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "MCP server: compose AI agents as Role + Persona + Framework + Skills. 12 roles, 10 personas, 16 framework refs. 5 typed tools. Bilingual FR+EN. stdio, no API key.",
   "description_fr": "Serveur MCP : composez des agents IA par Rôle + Persona + Framework + Skills. 12 rôles, 10 personas, 16 frameworks. 5 outils typés. Bilingue FR+EN.",
   "keywords": [

--- a/release-notes-v1.0.1.md
+++ b/release-notes-v1.0.1.md
@@ -1,0 +1,44 @@
+# @vantageos/mcp-agent-composer v1.0.1 — functional fix
+
+Released: 2026-04-26 (UTC)
+
+## What's fixed
+
+Same root cause as `@vantageos/mcp-frameworks@1.0.1`: Zod enum errors were being caught by the generic try/catch in `src/server.ts` and surfaced to the MCP client as a flat `"Internal error"` string — telling the model "something broke" but never **what** broke. Calling `compose_agent` with `role_id: "invented-role"` would just fail silently from the model's point of view.
+
+### Two-part fix
+
+1. **ZodError → readable Validation error payload.** The central `CallToolRequestSchema` handler in `src/server.ts` now intercepts `z.ZodError` — both at the top-level `inputSchema.parse(args)` step and inside the per-tool handler — and returns `{ isError: true, content: [{ type: "text", text: "Validation error: <path>: <msg>; ..." }] }`. The model gets the field name and the constraint that failed, so it can self-correct on the next turn.
+
+2. **Explicit `.describe()` on every enum.** `ROLE_ID`, `PERSONA_ID`, `FRAMEWORK_ID`, `LOCALE`, `ROLE_CATEGORY`, `PERSONA_AXIS`, `COMPOSITION_FORMAT` (in `src/schemas/index.ts`) plus the per-tool inline enums (`category` in `list_roles`, `axis` in `list_personas`) all now carry a description listing every accepted value. The MCP `tools/list` payload exposed to the client surfaces these descriptions, so models can pick valid IDs without first calling `list_roles` / `list_personas` for trivial choices.
+
+## What's NOT changed
+
+The data layer is byte-for-byte identical to v1.0.0:
+
+- 12 roles in `src/data/roles.ts`
+- 10 personas in `src/data/personas.ts`
+- 16 framework-steps in `src/data/framework-steps.ts`
+
+No tool semantics changed. No output shape changed. Pure functional polish.
+
+## Hard gates passed
+
+- `npm test` — 35/35 green (3 new tests in `tests/unit/zod-error-handling.test.ts`)
+- `npm run evals` — 15/15 green
+- Pre-publish leak audit — 0 hits on `SELLABLE AS` / `INTERNAL ONLY` / API-key patterns
+- Functional hard gate (3 cases): invalid role_id → `isError` + `role_id` message; goal < 20 chars → `isError`; valid call → success
+
+## Install
+
+```bash
+npm install @vantageos/mcp-agent-composer@1.0.1
+```
+
+Or via Claude Code:
+
+```bash
+claude mcp add agent-composer -- npx -y @vantageos/mcp-agent-composer
+```
+
+Orchestrator: Gamma — VantageOS Team | 2026-04-26

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -4,37 +4,45 @@ import { z } from "zod";
  * Canonical 12 role identifiers — single source of truth.
  * Critical Rule #4 : no z.any anywhere ; all role inputs go through this enum.
  */
-export const ROLE_ID = z.enum([
-  "technical-architect",
-  "senior-developer",
-  "qa-engineer",
-  "data-analyst",
-  "product-manager",
-  "creative-director",
-  "copywriter",
-  "researcher",
-  "business-strategist",
-  "operations-manager",
-  "tech-lead",
-  "executive-coach",
-]);
+export const ROLE_ID = z
+  .enum([
+    "technical-architect",
+    "senior-developer",
+    "qa-engineer",
+    "data-analyst",
+    "product-manager",
+    "creative-director",
+    "copywriter",
+    "researcher",
+    "business-strategist",
+    "operations-manager",
+    "tech-lead",
+    "executive-coach",
+  ])
+  .describe(
+    "Role: 'technical-architect' | 'senior-developer' | 'qa-engineer' | 'data-analyst' | 'product-manager' | 'creative-director' | 'copywriter' | 'researcher' | 'business-strategist' | 'operations-manager' | 'tech-lead' | 'executive-coach' (12 roles)",
+  );
 export type RoleId = z.infer<typeof ROLE_ID>;
 
 /**
  * Canonical 10 persona identifiers — single source of truth.
  */
-export const PERSONA_ID = z.enum([
-  "socratic-questioner",
-  "direct-pragmatist",
-  "warm-mentor",
-  "formal-academic",
-  "playful-creative",
-  "concise-executive",
-  "detailed-explainer",
-  "provocative-challenger",
-  "empathetic-listener",
-  "precise-analyst",
-]);
+export const PERSONA_ID = z
+  .enum([
+    "socratic-questioner",
+    "direct-pragmatist",
+    "warm-mentor",
+    "formal-academic",
+    "playful-creative",
+    "concise-executive",
+    "detailed-explainer",
+    "provocative-challenger",
+    "empathetic-listener",
+    "precise-analyst",
+  ])
+  .describe(
+    "Persona: 'socratic-questioner' | 'direct-pragmatist' | 'warm-mentor' | 'formal-academic' | 'playful-creative' | 'concise-executive' | 'detailed-explainer' | 'provocative-challenger' | 'empathetic-listener' | 'precise-analyst' (10 personas)",
+  );
 export type PersonaId = z.infer<typeof PERSONA_ID>;
 
 /**
@@ -43,49 +51,52 @@ export type PersonaId = z.infer<typeof PERSONA_ID>;
  * server. We keep this as a flat enum (no runtime dep) so this server can
  * compose offline.
  */
-export const FRAMEWORK_ID = z.enum([
-  "design-thinking",
-  "lean-startup",
-  "swot",
-  "okr",
-  "mece",
-  "first-principles",
-  "5-whys",
-  "eisenhower",
-  "raci",
-  "ooda",
-  "bcg-matrix",
-  "porter-5-forces",
-  "pareto",
-  "hofstede",
-  "cynefin",
-  "mckinsey-7s",
-]);
+export const FRAMEWORK_ID = z
+  .enum([
+    "design-thinking",
+    "lean-startup",
+    "swot",
+    "okr",
+    "mece",
+    "first-principles",
+    "5-whys",
+    "eisenhower",
+    "raci",
+    "ooda",
+    "bcg-matrix",
+    "porter-5-forces",
+    "pareto",
+    "hofstede",
+    "cynefin",
+    "mckinsey-7s",
+  ])
+  .describe(
+    "Framework: 'design-thinking' | 'lean-startup' | 'swot' | 'okr' | 'mece' | 'first-principles' | '5-whys' | 'eisenhower' | 'raci' | 'ooda' | 'bcg-matrix' | 'porter-5-forces' | 'pareto' | 'hofstede' | 'cynefin' | 'mckinsey-7s' (16 — mirrored from @vantageos/mcp-frameworks)",
+  );
 export type FrameworkId = z.infer<typeof FRAMEWORK_ID>;
 
-export const LOCALE = z.enum(["en", "fr"]);
+export const LOCALE = z
+  .enum(["en", "fr"])
+  .describe("Locale: 'en' (default) | 'fr'");
 export type Locale = z.infer<typeof LOCALE>;
 
-export const ROLE_CATEGORY = z.enum([
-  "technical",
-  "creative",
-  "analytical",
-  "operational",
-  "leadership",
-]);
+export const ROLE_CATEGORY = z
+  .enum(["technical", "creative", "analytical", "operational", "leadership"])
+  .describe(
+    "Role category: 'technical' | 'creative' | 'analytical' | 'operational' | 'leadership'",
+  );
 export type RoleCategory = z.infer<typeof ROLE_CATEGORY>;
 
-export const PERSONA_AXIS = z.enum([
-  "formality",
-  "energy",
-  "directness",
-  "domain_focus",
-]);
+export const PERSONA_AXIS = z
+  .enum(["formality", "energy", "directness", "domain_focus"])
+  .describe(
+    "Persona axis: 'formality' | 'energy' | 'directness' | 'domain_focus'",
+  );
 export type PersonaAxis = z.infer<typeof PERSONA_AXIS>;
 
-export const COMPOSITION_FORMAT = z.enum([
-  "system_prompt",
-  "json_definition",
-  "markdown_card",
-]);
+export const COMPOSITION_FORMAT = z
+  .enum(["system_prompt", "json_definition", "markdown_card"])
+  .describe(
+    "Output format: 'system_prompt' (default) | 'json_definition' | 'markdown_card'",
+  );
 export type CompositionFormat = z.infer<typeof COMPOSITION_FORMAT>;

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,6 +10,7 @@ import { tool as listPersonas } from "./tools/list_personas.js";
 import { tool as composeAgent } from "./tools/compose_agent.js";
 import { tool as suggestComposition } from "./tools/suggest_composition.js";
 import { tool as validateComposition } from "./tools/validate_composition.js";
+import { z } from "zod";
 import { logger } from "./lib/logger.js";
 import { ComposerError } from "./lib/errors.js";
 
@@ -22,7 +23,7 @@ export const TOOLS = [
 ] as const;
 
 export const SERVER_NAME = "vantage-agent-composer-mcp";
-export const SERVER_VERSION = "1.0.0";
+export const SERVER_VERSION = "1.0.1";
 
 type AnyTool = (typeof TOOLS)[number];
 
@@ -97,14 +98,52 @@ export function createServer(): VantageAgentComposerServer {
               content: [{ type: "text", text: `Unknown tool: ${name}` }],
             };
           }
+          let validatedArgs: unknown;
+          try {
+            validatedArgs = target.inputSchema.parse(args);
+          } catch (err) {
+            if (err instanceof z.ZodError) {
+              const msg = err.errors
+                .map(
+                  (e) =>
+                    `${e.path.join(".") || "<root>"}: ${e.message}`,
+                )
+                .join("; ");
+              logger.warn({ tool: name, error: "VALIDATION_ERROR", msg });
+              return {
+                isError: true,
+                content: [
+                  { type: "text", text: `Validation error: ${msg}` },
+                ],
+              };
+            }
+            throw err;
+          }
           try {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const out = await (target.handler as (i: any) => Promise<unknown>)(args);
+            const out = await (target.handler as (i: any) => Promise<unknown>)(
+              validatedArgs,
+            );
             return {
               content: [{ type: "text", text: JSON.stringify(out) }],
               structuredContent: out,
             };
           } catch (err) {
+            if (err instanceof z.ZodError) {
+              const msg = err.errors
+                .map(
+                  (e) =>
+                    `${e.path.join(".") || "<root>"}: ${e.message}`,
+                )
+                .join("; ");
+              logger.warn({ tool: name, error: "VALIDATION_ERROR", msg });
+              return {
+                isError: true,
+                content: [
+                  { type: "text", text: `Validation error: ${msg}` },
+                ],
+              };
+            }
             if (err instanceof ComposerError) {
               logger.warn({ tool: name, error: err.code });
               return {

--- a/src/tools/compose_agent.ts
+++ b/src/tools/compose_agent.ts
@@ -30,8 +30,11 @@ export const inputSchema = z.object({
     .string()
     .min(20)
     .max(500)
-    .describe("Brief context for the agent's purpose"),
-  locale: z.enum(["en", "fr"]).default("en"),
+    .describe("Brief context for the agent's purpose (20-500 chars)"),
+  locale: z
+    .enum(["en", "fr"])
+    .default("en")
+    .describe("Locale: 'en' (default) | 'fr'"),
   format: COMPOSITION_FORMAT.default("system_prompt"),
 });
 

--- a/src/tools/list_personas.ts
+++ b/src/tools/list_personas.ts
@@ -6,8 +6,13 @@ export const inputSchema = z.object({
   axis: z
     .enum(["formality", "energy", "directness", "domain_focus", "all"])
     .default("all")
-    .describe("Filter personas by axis"),
-  locale: z.enum(["en", "fr"]).default("en").describe("Locale for descriptions"),
+    .describe(
+      "Persona axis: 'all' (default) | 'formality' | 'energy' | 'directness' | 'domain_focus'",
+    ),
+  locale: z
+    .enum(["en", "fr"])
+    .default("en")
+    .describe("Locale: 'en' (default) | 'fr'"),
 });
 
 export const outputSchema = z.object({

--- a/src/tools/list_roles.ts
+++ b/src/tools/list_roles.ts
@@ -6,8 +6,13 @@ export const inputSchema = z.object({
   category: z
     .enum(["technical", "creative", "analytical", "operational", "leadership", "all"])
     .default("all")
-    .describe("Filter roles by category"),
-  locale: z.enum(["en", "fr"]).default("en").describe("Locale for descriptions"),
+    .describe(
+      "Filter category: 'all' (default) | 'technical' | 'creative' | 'analytical' | 'operational' | 'leadership'",
+    ),
+  locale: z
+    .enum(["en", "fr"])
+    .default("en")
+    .describe("Locale: 'en' (default) | 'fr'"),
 });
 
 export const outputSchema = z.object({

--- a/src/tools/suggest_composition.ts
+++ b/src/tools/suggest_composition.ts
@@ -10,13 +10,16 @@ export const inputSchema = z.object({
     .string()
     .min(20)
     .max(300)
-    .describe("What you want the agent to accomplish"),
+    .describe("Goal: what you want the agent to accomplish (20-300 chars)"),
   constraints: z
     .array(z.string())
     .max(5)
     .optional()
     .describe("Optional constraints (e.g. 'must be concise', 'no jargon')"),
-  locale: z.enum(["en", "fr"]).default("en"),
+  locale: z
+    .enum(["en", "fr"])
+    .default("en")
+    .describe("Locale: 'en' (default) | 'fr'"),
 });
 
 // MINOR FIX #2: role_id, persona_id, framework_id use ROLE_ID/PERSONA_ID/FRAMEWORK_ID enums.

--- a/src/tools/validate_composition.ts
+++ b/src/tools/validate_composition.ts
@@ -11,7 +11,10 @@ export const inputSchema = z.object({
   persona_id: PERSONA_ID,
   framework_id: FRAMEWORK_ID.optional(),
   skills: z.array(z.string()).optional(),
-  locale: z.enum(["en", "fr"]).default("en"),
+  locale: z
+    .enum(["en", "fr"])
+    .default("en")
+    .describe("Locale: 'en' (default) | 'fr'"),
 });
 
 export const outputSchema = z.object({

--- a/tests/unit/zod-error-handling.test.ts
+++ b/tests/unit/zod-error-handling.test.ts
@@ -1,0 +1,106 @@
+import { describe, test, expect } from "vitest";
+import { z } from "zod";
+import { TOOLS } from "../../src/server.js";
+import { ComposerError } from "../../src/lib/errors.js";
+
+/**
+ * Simulates the central server CallTool handler path :
+ *   1. inputSchema.parse(args) → ZodError → readable Validation error isError
+ *   2. handler(parsed) → ComposerError → isError | success → content+structuredContent
+ *
+ * Mirrors src/server.ts CallToolRequestSchema branch so unit tests exercise the
+ * same wrapping logic that the MCP transport will hit at runtime.
+ */
+async function callTool(
+  name: string,
+  args: unknown,
+): Promise<{
+  isError?: boolean;
+  content: Array<{ type: string; text: string }>;
+  structuredContent?: unknown;
+}> {
+  const target = TOOLS.find((t) => t.name === name);
+  if (!target) {
+    return {
+      isError: true,
+      content: [{ type: "text", text: `Unknown tool: ${name}` }],
+    };
+  }
+  let validated: unknown;
+  try {
+    validated = target.inputSchema.parse(args);
+  } catch (e) {
+    if (e instanceof z.ZodError) {
+      const msg = e.errors
+        .map((err) => `${err.path.join(".") || "<root>"}: ${err.message}`)
+        .join("; ");
+      return {
+        isError: true,
+        content: [{ type: "text", text: `Validation error: ${msg}` }],
+      };
+    }
+    throw e;
+  }
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const out = await (target.handler as (i: any) => Promise<unknown>)(
+      validated,
+    );
+    return {
+      content: [{ type: "text", text: JSON.stringify(out) }],
+      structuredContent: out,
+    };
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      const msg = err.errors
+        .map((e) => `${e.path.join(".") || "<root>"}: ${e.message}`)
+        .join("; ");
+      return {
+        isError: true,
+        content: [{ type: "text", text: `Validation error: ${msg}` }],
+      };
+    }
+    if (err instanceof ComposerError) {
+      return {
+        isError: true,
+        content: [{ type: "text", text: err.message }],
+      };
+    }
+    return {
+      isError: true,
+      content: [{ type: "text", text: "Internal error" }],
+    };
+  }
+}
+
+describe("zod-error-handling — readable Validation errors via isError", () => {
+  test("compose_agent returns isError on invalid role_id", async () => {
+    const result = await callTool("compose_agent", {
+      role_id: "invented-role",
+      persona_id: "direct-pragmatist",
+      context: "A 20+ char context string here for valid context length",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/role_id/);
+    expect(result.content[0].text).toMatch(/Validation error/);
+  });
+
+  test("suggest_composition returns isError when goal too short (<20 chars)", async () => {
+    const result = await callTool("suggest_composition", {
+      goal: "short",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/goal/);
+  });
+
+  test("compose_agent succeeds on valid input", async () => {
+    const result = await callTool("compose_agent", {
+      role_id: "technical-architect",
+      persona_id: "direct-pragmatist",
+      framework_id: "first-principles",
+      context: "A 20+ char context string here for valid input",
+    });
+    expect(result.isError).toBeFalsy();
+    expect(result.structuredContent).toBeDefined();
+  });
+});


### PR DESCRIPTION
URGENT functional fix v1.0.1. 

## Bugs fixed
- Zod enum errors swallowed as 'Internal error' → now return readable `{isError:true, content:[{text:'Validation error: <field>: <reason>'}]}` per MCP spec
- Tool input schema descriptions now list explicit enum values

## Verification
- 35/35 tests pass (incl 3 new hard-gate tests)
- 15/15 evals green
- Pre-publish leak audit: 0 hits
- Version parity 1.0.1/1.0.1

## Hard-gate Pi spec (3/3 PASS)
- T1: invalid role_id → isError + readable
- T2: goal too short → isError
- T3: valid input → success

Built by: mcp-publisher (via gamma) | bu-mcp BU | 2026-04-26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Server now properly handles validation failures with readable error messages including field paths and details, instead of generic "Internal error" responses.

* **Improvements**
  * Tool input parameters now include comprehensive descriptions listing all allowed values for roles, personas, frameworks, locales, categories, axes, and formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->