### PR TITLE
fix: v1.0.3 bug #3 audit + smoke test gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## [1.0.3] - 2026-04-26
+### Audited
+- Bug #3 input duplication audit on compose_agent / validate_composition / suggest_composition: none found, all clean.
+
+### Added
+- Pre-publish boot smoke test gate (`scripts/smoke-test-boot.sh` + `prepublishOnly`). `node dist/index.js` must respond to MCP `initialize` handshake before publish proceeds. Lesson #11 fleet-wide capture (Day 51 PM C v1.0.4 broken-publish incident).
+
+### Notes
+- mcp.json bumped 1.0.0 → 1.0.3 to restore version parity with package.json (was lagging since v1.0.0 release).
+
+[1.0.3]: https://github.com/elpiarthera/vantage-agent-composer-mcp/releases/tag/v1.0.3
+
+## [1.0.2] — 2026-04-26
+
+### Fixed
+- Build artifacts: ship `dist/` so `npx -y @vantageos/mcp-agent-composer` works post-install (Laurent manual fix post Pi-override).
+
+[1.0.2]: https://github.com/elpiarthera/vantage-agent-composer-mcp/releases/tag/v1.0.2
+
 ## [1.0.1] — 2026-04-26
 
 ### Fixed

--- a/mcp.json
+++ b/mcp.json
@@ -1,6 +1,6 @@
 {
   "name": "vantage-agent-composer-mcp",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "description": "MCP server: compose AI agents as Role + Persona + Framework + Skills. 12 roles, 10 personas, 16 framework refs. 5 typed tools. Bilingual FR+EN. stdio, no API key.",
   "description_fr": "Serveur MCP : composez des agents IA par Rôle + Persona + Framework + Skills. 12 rôles, 10 personas, 16 frameworks. 5 outils typés. Bilingue FR+EN.",
   "transport": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vantageos/mcp-agent-composer",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vantageos/mcp-agent-composer",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vantageos/mcp-agent-composer",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "MCP server: compose AI agents as Role + Persona + Framework + Skills. 12 roles, 10 personas, 16 framework refs. 5 typed tools. Bilingual FR+EN. stdio, no API key.",
   "description_fr": "Serveur MCP : composez des agents IA par Rôle + Persona + Framework + Skills. 12 rôles, 10 personas, 16 frameworks. 5 outils typés. Bilingue FR+EN.",
   "keywords": [
@@ -43,7 +43,9 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "evals": "node scripts/run-evals.js",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "smoke": "bash scripts/smoke-test-boot.sh",
+    "prepublishOnly": "npm run build && npm run smoke && npm test && npm run evals"
   },
   "engines": {
     "node": ">=20"

--- a/release-notes-v1.0.3.md
+++ b/release-notes-v1.0.3.md
@@ -1,0 +1,21 @@
+# v1.0.3 — Bug #3 audit + smoke test gate
+
+## Audited
+- **Bug #3 input duplication pattern** swept across `compose_agent`, `validate_composition`, and `suggest_composition`. **No occurrences found** — all three tools keep user input in `structuredContent` top-level only and never re-interpolate `${context}` / `${goal}` / `${requirement}` truncated inside sub-section results (`composition_notes`, `warnings`, `recommendations`, `suggestions[].rationale`). Static catalog data (role names, framework steps) is the only thing referenced in output strings.
+
+## Added
+- `scripts/smoke-test-boot.sh` — sends MCP `initialize` handshake to `node dist/index.js` with a 5s timeout and asserts `"protocolVersion"` in response.
+- `npm run smoke` script.
+- `prepublishOnly`: `npm run build && npm run smoke && npm test && npm run evals` — publish is now gated on a working boot. Lesson #11 fleet-wide capture (Day 51 PM C v1.0.4 broken-publish incident).
+
+## Fixed (parity)
+- `mcp.json` version bumped 1.0.0 → 1.0.3 to restore parity with `package.json` (mcp.json had been lagging since v1.0.0 release).
+
+## Stats
+- Tests: 35/35 pass
+- Evals: 15/15 pass
+- Smoke: PASS
+
+Built by: mcp-publisher (via gamma) | bu-mcp BU | 2026-04-26
+
+Orchestrator: Gamma — VantageOS Team | 2026-04-26

--- a/scripts/smoke-test-boot.sh
+++ b/scripts/smoke-test-boot.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+SMOKE=$(echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke","version":"1.0"}}}' | timeout 5 node dist/index.js 2>&1)
+if [[ "$SMOKE" != *'"protocolVersion"'* ]]; then
+  echo "FATAL: server did not respond to initialize"
+  echo "Output: $SMOKE"
+  exit 1
+fi
+echo "Smoke test PASS — server responds to initialize"


### PR DESCRIPTION
## Summary
- **Bug #3 audit** on `compose_agent` / `validate_composition` / `suggest_composition`: input duplication pattern (truncated `\${context}` / `\${goal}` re-interpolated inside output sub-sections). **None found, all clean.** Inputs stay in `structuredContent` top-level only.
- **Smoke test gate** added: `scripts/smoke-test-boot.sh` + `npm run smoke` + `prepublishOnly` hook. Pre-publish boot validation via MCP `initialize` handshake. Lesson #11 fleet-wide capture (Day 51 PM C v1.0.4 broken-publish incident).
- **Version parity** restored: `mcp.json` 1.0.0 → 1.0.3 (was lagging since v1.0.0).

## Stats
- Tests: 35/35 pass
- Evals: 15/15 pass
- Smoke: PASS locally

## Why a PR (not direct push)
Direct push to master is blocked by the harness chain-of-trust safeguard (Day 51 PM history). Per task brief, requesting Pi override merge.

## Test plan
- [x] `npm install`
- [x] `npm run build`
- [x] `npm run smoke` — PASS
- [x] `npm test` — 35/35
- [x] `npm run evals` — 15/15

Built by: mcp-publisher (via gamma) | bu-mcp BU | 2026-04-26

Orchestrator: Gamma — VantageOS Team | 2026-04-26