### PR TITLE
fix: v1.0.4 suggest_composition keyword matching (Closes #3)

### DIFF
--- a/BLOCKED.md
+++ b/BLOCKED.md
@@ -1,0 +1,56 @@
+# BLOCKED — v1.0.4 awaiting Eta APPROVED + Pi override merge
+
+**Date (UTC)** : 2026-04-26T18:50:00Z
+**Orchestrator** : Gamma (γ)
+**BU** : bu-mcp
+**Repo** : @vantageos/mcp-agent-composer
+
+## Status
+v1.0.4 work is complete locally, pushed to feature branch, PR created.
+Auto-merge blocked by `enforce-merge-gate.py` hook (Day 51 PM chain-of-trust safeguard):
+requires Eta APPROVED annotation OR Pi explicit `GO MERGE PR #5` override comment.
+
+## Pull Request
+- **PR #5** : https://github.com/elpiarthera/vantage-agent-composer-mcp/pull/5
+- **Branch** : `fix/issue-3-suggest-matching`
+- **Commit** : 92e079d
+- **Base** : `master`
+
+## What's in the PR (v1.0.4)
+1. **Bug #3 fix** — `suggest_composition` keyword index FR+EN per role (`src/data/role-keywords.ts`):
+   - 12 roles, 150+ keywords (FR+EN mixed)
+   - Multi-word phrase match: +3 | Single token: +1
+   - Top-scored role(s) win (up to 3). Generic fallback (tech-lead) ONLY when all scores = 0.
+2. **Tests** — 10 new unit tests (`tests/unit/suggest_composition-keyword-matching.test.ts`)
+3. **Evals** — 5 new evals #16–#20 (`evals/evals.json`)
+4. **Version bump** — package.json + mcp.json 1.0.3 → 1.0.4
+5. **CHANGELOG** entry for v1.0.4
+
+## Local validation (all green)
+- `npm run build` — OK
+- `npm run smoke` — PASS
+- `npm test` — 45/45 pass (incl. 10 new keyword tests)
+- `npm run evals` — 20/20 pass (incl. 5 new evals)
+- Leak audit — 0 hits
+
+## Hard-gate acceptance criteria (all PASS)
+- "Rédiger des posts LinkedIn pour X" → `copywriter` top 1: PASS
+- "Build a CI/CD pipeline" → `tech-lead`/`senior-dev`/`technical-architect` top 1: PASS
+- "Run a market analysis" → `business-strategist`/`data-analyst` top 1: PASS
+- Generic fallback only when no keyword match: PASS
+
+## What Pi/Laurent needs to do
+**Option A (Eta)**: Request Eta to post `gh pr review 5 --comment --body "Eta APPROVED ..."` then rerun merge.
+**Option B (Pi override)**: Post explicit override comment `GO MERGE PR #5 — scope verified` on GitHub PR #5.
+
+Once merged, Gamma will:
+1. `git pull --ff-only origin master && git tag v1.0.4 && git push origin v1.0.4`
+2. `npm publish --access public` (prepublishOnly hook re-gates build/smoke/test/evals)
+3. `gh release create v1.0.4 ...`
+4. Upsert VR plugin `jd7cnkqv4zn75jfexn52kpqmhs85j4rt` to v1.0.4
+5. Close GitHub issue #3 with comment
+
+## STOP rationale
+Per Day 51 PM chain-of-trust safeguard: DO NOT post fake Pi-override comments. STOP and report.
+
+Orchestrator: Gamma — VantageOS Team | 2026-04-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [1.0.4] - 2026-04-26
+### Fixed
+- `suggest_composition` matching: added keyword index FR+EN per role (`src/data/role-keywords.ts`). Generic fallback (tech-lead) only triggers when no keyword matches. Closes #3 (user-reported "Rédiger posts LinkedIn" → tech-lead instead of copywriter).
+- 12 roles now have comprehensive FR+EN keyword arrays (150+ keywords total). Multi-word phrases scored +3 vs single tokens +1.
+- Scores are deterministic, monotonically non-increasing in output.
+
+### Tests
+- 10 new unit tests in `tests/unit/suggest_composition-keyword-matching.test.ts` covering FR+EN keyword matching and generic fallback.
+- 5 new evals (#16–#20) in `evals/evals.json` for keyword-matching acceptance criteria.
+- 45/45 unit tests + 20/20 evals green.
+
+[1.0.4]: https://github.com/elpiarthera/vantage-agent-composer-mcp/releases/tag/v1.0.4
+
 ## [1.0.3] - 2026-04-26
 ### Audited
 - Bug #3 input duplication audit on compose_agent / validate_composition / suggest_composition: none found, all clean.

--- a/evals/evals.json
+++ b/evals/evals.json
@@ -202,6 +202,77 @@
       },
       "expected_output": "Validation error.",
       "expectations": ["handler throws"]
+    },
+    {
+      "id": 16,
+      "tool": "suggest_composition",
+      "prompt": "FR: Rédiger des posts LinkedIn → top match copywriter (Issue #3 fix).",
+      "input": {
+        "goal": "Rédiger des posts LinkedIn pour promouvoir notre nouvelle offre de service.",
+        "locale": "fr"
+      },
+      "expected_output": "Top suggestion role_id === copywriter.",
+      "expectations": [
+        "tool 'suggest_composition' was called",
+        "output.suggestions[0].role_id === 'copywriter'"
+      ]
+    },
+    {
+      "id": 17,
+      "tool": "suggest_composition",
+      "prompt": "EN: Build CI/CD pipeline → top match tech-lead, senior-developer, or technical-architect.",
+      "input": {
+        "goal": "Build a CI/CD pipeline to deploy our infrastructure automatically on every merge.",
+        "locale": "en"
+      },
+      "expected_output": "Top suggestion role_id is a technical role (tech-lead, senior-developer, or technical-architect).",
+      "expectations": [
+        "tool 'suggest_composition' was called",
+        "output.suggestions[0].role_id in ['tech-lead','senior-developer','technical-architect']"
+      ]
+    },
+    {
+      "id": 18,
+      "tool": "suggest_composition",
+      "prompt": "EN: Run market analysis → top match business-strategist or data-analyst.",
+      "input": {
+        "goal": "Run a market analysis on our main competitors and assess our positioning strategy.",
+        "locale": "en"
+      },
+      "expected_output": "Top suggestion role_id is business-strategist, data-analyst, or researcher.",
+      "expectations": [
+        "tool 'suggest_composition' was called",
+        "output.suggestions[0].role_id in ['business-strategist','data-analyst','researcher']"
+      ]
+    },
+    {
+      "id": 19,
+      "tool": "suggest_composition",
+      "prompt": "FR: Auditer stratégie produit → top match product-manager or business-strategist.",
+      "input": {
+        "goal": "Auditer notre stratégie produit et proposer une nouvelle roadmap pour Q3 2026.",
+        "locale": "fr"
+      },
+      "expected_output": "Top suggestion role_id is product-manager or business-strategist.",
+      "expectations": [
+        "tool 'suggest_composition' was called",
+        "output.suggestions[0].role_id in ['product-manager','business-strategist']"
+      ]
+    },
+    {
+      "id": 20,
+      "tool": "suggest_composition",
+      "prompt": "Generic ambiguous goal → fallback tech-lead.",
+      "input": {
+        "goal": "I want a helpful assistant but I am not sure what for exactly yet.",
+        "locale": "en"
+      },
+      "expected_output": "Fallback suggestion: top role_id === tech-lead.",
+      "expectations": [
+        "tool 'suggest_composition' was called",
+        "output.suggestions[0].role_id === 'tech-lead'",
+        "every suggestion has rationale and rationale_fr"
+      ]
     }
   ]
 }

--- a/mcp.json
+++ b/mcp.json
@@ -1,6 +1,6 @@
 {
   "name": "vantage-agent-composer-mcp",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "MCP server: compose AI agents as Role + Persona + Framework + Skills. 12 roles, 10 personas, 16 framework refs. 5 typed tools. Bilingual FR+EN. stdio, no API key.",
   "description_fr": "Serveur MCP : composez des agents IA par Rôle + Persona + Framework + Skills. 12 rôles, 10 personas, 16 frameworks. 5 outils typés. Bilingue FR+EN.",
   "transport": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vantageos/mcp-agent-composer",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "MCP server: compose AI agents as Role + Persona + Framework + Skills. 12 roles, 10 personas, 16 framework refs. 5 typed tools. Bilingual FR+EN. stdio, no API key.",
   "description_fr": "Serveur MCP : composez des agents IA par Rôle + Persona + Framework + Skills. 12 rôles, 10 personas, 16 frameworks. 5 outils typés. Bilingue FR+EN.",
   "keywords": [

--- a/src/data/role-keywords.ts
+++ b/src/data/role-keywords.ts
@@ -1,0 +1,404 @@
+/**
+ * role-keywords.ts — Keyword index FR+EN per role for suggest_composition matching.
+ *
+ * Fix for GitHub issue #3: generic fallback (tech-lead) was returned even when
+ * goal contained explicit role keywords (e.g. "rédiger posts LinkedIn" → copywriter).
+ *
+ * Design:
+ *  - Each role has a flat keyword array (FR+EN mixed).
+ *  - Tokenization is lowercase + word split (simple, no external deps).
+ *  - Scoring: +2 for exact multi-word phrase match, +1 for single-word token match.
+ *  - Highest scoring role wins. Zero score → generic fallback.
+ *
+ * Bilingual FR+EN by design (Critical Rule #1).
+ * Source: bu-mcp spec §3 fix T3 | vantage-agent-composer v1.0.4
+ */
+
+export interface RoleKeywordEntry {
+  role_id: string;
+  /** Keywords / phrases, lowercase. Multi-word phrases scored higher than single tokens. */
+  keywords: string[];
+}
+
+export const ROLE_KEYWORDS: RoleKeywordEntry[] = [
+  {
+    role_id: "copywriter",
+    keywords: [
+      // FR
+      "rédiger",
+      "rédaction",
+      "post",
+      "posts",
+      "linkedin",
+      "twitter",
+      "blog",
+      "newsletter",
+      "copie",
+      "texte",
+      "accroche",
+      "slogan",
+      "tagline",
+      "contenu",
+      "écrire",
+      "écriture",
+      "publier",
+      "publication",
+      "rédacteur",
+      "rédactrice",
+      "storytelling",
+      // EN
+      "copy",
+      "copywriting",
+      "write",
+      "writing",
+      "draft",
+      "compose",
+      "post",
+      "tweet",
+      "headline",
+      "tagline",
+      "marketing copy",
+      "email copy",
+      "ad copy",
+      "content",
+      "brand voice",
+      "content writing",
+      "social media content",
+    ],
+  },
+  {
+    role_id: "creative-director",
+    keywords: [
+      // FR
+      "créatif",
+      "créative",
+      "direction créative",
+      "vision créative",
+      "concept",
+      "branding",
+      "campagne",
+      "identité visuelle",
+      "direction artistique",
+      "charte graphique",
+      // EN
+      "creative",
+      "creative direction",
+      "creative vision",
+      "branding",
+      "art direction",
+      "campaign creative",
+      "visual identity",
+      "brand concept",
+      "ideation",
+      "new product",
+      "innovate",
+      "blank page",
+      "ideate",
+    ],
+  },
+  {
+    role_id: "data-analyst",
+    keywords: [
+      // FR
+      "données",
+      "data",
+      "analyse",
+      "analyser",
+      "statistiques",
+      "tableau de bord",
+      "indicateurs",
+      "métriques",
+      "tendance",
+      "graphique",
+      "rapport",
+      "visualisation",
+      // EN
+      "data",
+      "analytic",
+      "analytics",
+      "analyze",
+      "analysis",
+      "statistics",
+      "dashboard",
+      "metrics",
+      "kpi",
+      "trend",
+      "chart",
+      "reporting",
+      "sql",
+      "visualization",
+      "dataset",
+    ],
+  },
+  {
+    role_id: "product-manager",
+    keywords: [
+      // FR
+      "produit",
+      "feature",
+      "fonctionnalité",
+      "roadmap",
+      "feuille de route",
+      "user story",
+      "sprint",
+      "backlog",
+      "priorité",
+      "prioriser",
+      "prd",
+      "cahier des charges produit",
+      "problème utilisateur",
+      // EN
+      "product",
+      "feature",
+      "roadmap",
+      "user story",
+      "sprint",
+      "prd",
+      "product requirements",
+      "prioritize",
+      "prioritise",
+      "prioriti",
+      "overload",
+      "too many",
+      "backlog",
+      "decide between",
+      "product strategy",
+      "product vision",
+    ],
+  },
+  {
+    role_id: "technical-architect",
+    keywords: [
+      // FR
+      "architecture",
+      "système distribué",
+      "microservices",
+      "scalabilité",
+      "infrastructure",
+      "api",
+      "contrats d'api",
+      "blueprint",
+      "conception système",
+      // EN
+      "architecture",
+      "system design",
+      "distributed systems",
+      "microservices",
+      "scalability",
+      "infrastructure",
+      "api contracts",
+      "design system",
+      "tech stack",
+      "cloud architecture",
+    ],
+  },
+  {
+    role_id: "tech-lead",
+    keywords: [
+      // FR
+      "code",
+      "implémenter",
+      "refactoring",
+      "ci/cd",
+      "pipeline",
+      "déployer",
+      "livraison",
+      "équipe technique",
+      "dette technique",
+      // EN
+      "code",
+      "implement",
+      "refactor",
+      "ci/cd",
+      "deploy",
+      "build pipeline",
+      "delivery",
+      "tech team",
+      "tech debt",
+      "engineering team",
+      "ship",
+    ],
+  },
+  {
+    role_id: "senior-developer",
+    keywords: [
+      // FR
+      "développement",
+      "code",
+      "bug",
+      "debug",
+      "debugger",
+      "revue de code",
+      "pull request",
+      "tests unitaires",
+      // EN
+      "development",
+      "coding",
+      "debugging",
+      "code review",
+      "pull request",
+      "unit tests",
+      "refactoring",
+      "pair programming",
+    ],
+  },
+  {
+    role_id: "qa-engineer",
+    keywords: [
+      // FR
+      "tests",
+      "qa",
+      "régression",
+      "qualité",
+      "scénario de test",
+      "automatisation des tests",
+      "bug",
+      // EN
+      "test",
+      "qa",
+      "playwright",
+      "regression",
+      "bug",
+      "quality assurance",
+      "test automation",
+      "test plan",
+      "test coverage",
+      "incident",
+      "outage",
+      "production",
+      "rollback",
+    ],
+  },
+  {
+    role_id: "researcher",
+    keywords: [
+      // FR
+      "recherche",
+      "étude",
+      "revue de littérature",
+      "enquête",
+      "analyser",
+      "investigation",
+      "veille",
+      // EN
+      "research",
+      "literature review",
+      "study",
+      "evidence",
+      "investigate",
+      "survey",
+      "academic",
+      "sources",
+      "findings",
+    ],
+  },
+  {
+    role_id: "business-strategist",
+    keywords: [
+      // FR
+      "stratégie",
+      "marché",
+      "concurrents",
+      "positionnement",
+      "go-to-market",
+      "swot",
+      "analyse concurrentielle",
+      "croissance",
+      "business model",
+      // EN
+      "strategy",
+      "strategic",
+      "market",
+      "competitor",
+      "go-to-market",
+      "positioning",
+      "swot",
+      "competitive analysis",
+      "growth",
+      "business model",
+      "roadmap",
+      "competitive",
+    ],
+  },
+  {
+    role_id: "operations-manager",
+    keywords: [
+      // FR
+      "opérations",
+      "ops",
+      "processus",
+      "procédure",
+      "sop",
+      "logistique",
+      "fournisseur",
+      "sla",
+      "vendor",
+      // EN
+      "operations",
+      "ops",
+      "process",
+      "sop",
+      "supply",
+      "logistics",
+      "vendor",
+      "sla",
+      "scale",
+      "workflow",
+      "procedure",
+    ],
+  },
+  {
+    role_id: "executive-coach",
+    keywords: [
+      // FR
+      "coaching",
+      "leadership",
+      "dirigeant",
+      "manager",
+      "feedback",
+      "mentorat",
+      "carrière",
+      "développement personnel",
+      "1:1",
+      // EN
+      "coach",
+      "coaching",
+      "leadership",
+      "1:1",
+      "one-on-one",
+      "feedback",
+      "mentoring",
+      "career",
+      "team morale",
+      "executive",
+      "development",
+    ],
+  },
+];
+
+/**
+ * Score a goal string against a single role's keyword list.
+ * Returns a score ≥ 0.
+ *  - Multi-word phrase match: +3 per hit (exact substring match on lowercased goal)
+ *  - Single-word token match: +1 per hit
+ */
+export function scoreRoleKeywords(
+  lowerGoal: string,
+  entry: RoleKeywordEntry,
+): number {
+  let score = 0;
+  for (const kw of entry.keywords) {
+    if (kw.includes(" ")) {
+      // Multi-word phrase: check substring match, worth more
+      if (lowerGoal.includes(kw)) {
+        score += 3;
+      }
+    } else {
+      // Single token: check whole-word-ish match (includes is fine for short phrases)
+      if (lowerGoal.includes(kw)) {
+        score += 1;
+      }
+    }
+  }
+  return score;
+}

--- a/src/tools/suggest_composition.ts
+++ b/src/tools/suggest_composition.ts
@@ -3,6 +3,7 @@ import { ROLE_ID, PERSONA_ID, FRAMEWORK_ID } from "../schemas/index.js";
 import { ROLES } from "../data/roles.js";
 import { PERSONAS } from "../data/personas.js";
 import { FRAMEWORK_STEPS } from "../data/framework-steps.js";
+import { ROLE_KEYWORDS, scoreRoleKeywords } from "../data/role-keywords.js";
 import { logger } from "../lib/logger.js";
 
 export const inputSchema = z.object({
@@ -52,194 +53,222 @@ interface ScoredSuggestion {
 }
 
 /**
- * Lightweight keyword-driven heuristic. The point is *not* full NLP — the spec
- * §8 evals only require that the suggestions are deterministic, scored, and
- * align with obvious goals (e.g., "debug production incidents" → technical
- * roles + 5-whys). Real ranking is a Phase 2 LLM-assisted refinement.
+ * Per-role persona + framework assignment table.
+ * Maps role_id → best {persona_id, framework_id, rationale EN+FR, base_score}.
+ * base_score is the score used when the role wins by keyword match.
+ * fit_score returned = base_score (0-100).
+ */
+const ROLE_COMPOSITIONS: Record<
+  string,
+  {
+    persona_id: z.infer<typeof PERSONA_ID>;
+    framework_id: z.infer<typeof FRAMEWORK_ID> | null;
+    rationale: string;
+    rationale_fr: string;
+    base_score: number;
+  }
+> = {
+  "copywriter": {
+    persona_id: "playful-creative",
+    framework_id: null,
+    rationale:
+      "Content and copy work benefits from a playful creative persona; an explicit framework would over-constrain ideation.",
+    rationale_fr:
+      "Le travail de contenu et de copie gagne avec un persona créatif joueur ; un framework explicite contraindrait trop l'idéation.",
+    base_score: 88,
+  },
+  "creative-director": {
+    persona_id: "playful-creative",
+    framework_id: "design-thinking",
+    rationale:
+      "Creative direction benefits from a Design Thinking loop to move from empathy to prototype.",
+    rationale_fr:
+      "La direction créative gagne avec une boucle Design Thinking pour passer de l'empathie au prototype.",
+    base_score: 86,
+  },
+  "data-analyst": {
+    persona_id: "precise-analyst",
+    framework_id: "pareto",
+    rationale:
+      "Data work pairs naturally with a precise-analyst voice and a Pareto lens to surface the vital few.",
+    rationale_fr:
+      "Le travail data se marie naturellement avec une voix d'analyste rigoureux et une lecture Pareto pour faire émerger l'essentiel.",
+    base_score: 84,
+  },
+  "product-manager": {
+    persona_id: "direct-pragmatist",
+    framework_id: "eisenhower",
+    rationale:
+      "When everything feels urgent, a PM with the Eisenhower matrix forces a single quadrant per task.",
+    rationale_fr:
+      "Quand tout semble urgent, un·e PM avec la matrice d'Eisenhower force un seul quadrant par tâche.",
+    base_score: 87,
+  },
+  "technical-architect": {
+    persona_id: "direct-pragmatist",
+    framework_id: "5-whys",
+    rationale:
+      "Architecture decisions need a technical owner who can drive a root-cause loop without sentiment.",
+    rationale_fr:
+      "Les décisions d'architecture réclament un·e architecte technique capable de mener une boucle de cause racine sans pathos.",
+    base_score: 90,
+  },
+  "tech-lead": {
+    persona_id: "direct-pragmatist",
+    framework_id: "first-principles",
+    rationale:
+      "Engineering delivery needs a pragmatic lead who challenges assumptions via first-principles thinking.",
+    rationale_fr:
+      "La delivery technique nécessite un lead pragmatique qui remet en cause les hypothèses par les premiers principes.",
+    base_score: 85,
+  },
+  "senior-developer": {
+    persona_id: "precise-analyst",
+    framework_id: "first-principles",
+    rationale:
+      "Complex code tasks benefit from an analytical, first-principles approach to avoid cargo-cult solutions.",
+    rationale_fr:
+      "Les tâches de code complexes gagnent avec une approche analytique et premiers principes pour éviter les solutions cargo-cult.",
+    base_score: 83,
+  },
+  "qa-engineer": {
+    persona_id: "precise-analyst",
+    framework_id: "cynefin",
+    rationale:
+      "QA precision plus a Cynefin classification keeps the team out of premature fixes when the situation is complex or chaotic.",
+    rationale_fr:
+      "La précision QA et un classement Cynefin évitent les correctifs prématurés quand la situation est complexe ou chaotique.",
+    base_score: 85,
+  },
+  "researcher": {
+    persona_id: "formal-academic",
+    framework_id: "mece",
+    rationale:
+      "Research outputs read better with a formal-academic voice structured by a MECE decomposition.",
+    rationale_fr:
+      "Les livrables de recherche se lisent mieux avec une voix formelle académique structurée par une décomposition MECE.",
+    base_score: 86,
+  },
+  "business-strategist": {
+    persona_id: "concise-executive",
+    framework_id: "swot",
+    rationale:
+      "Strategic asks land best with an executive-concise voice and a SWOT scaffold for evidence.",
+    rationale_fr:
+      "Les demandes stratégiques passent mieux avec une voix exécutive concise et un cadre SWOT comme support de preuves.",
+    base_score: 88,
+  },
+  "operations-manager": {
+    persona_id: "concise-executive",
+    framework_id: "raci",
+    rationale:
+      "Operations questions resolve faster with a concise-executive voice and a RACI to remove ownership ambiguity.",
+    rationale_fr:
+      "Les questions opérationnelles se résolvent plus vite avec une voix exécutive concise et un RACI pour lever l'ambiguïté de responsabilité.",
+    base_score: 83,
+  },
+  "executive-coach": {
+    persona_id: "warm-mentor",
+    framework_id: "cynefin",
+    rationale:
+      "Coaching contexts call for a warm mentor voice and a sense-making framework, not a checklist.",
+    rationale_fr:
+      "Les contextes de coaching appellent une voix de mentor bienveillant et un cadre de sense-making, pas une checklist.",
+    base_score: 90,
+  },
+};
+
+/**
+ * Score all roles against the goal using the keyword index.
+ * Returns top N (up to 3) matched roles with their compositions.
+ * If no role scores > 0, returns generic fallback (tech-lead).
+ *
+ * Fix for GitHub issue #3: keyword index FR+EN ensures "rédiger posts LinkedIn"
+ * correctly returns copywriter instead of the generic tech-lead fallback.
  */
 function scoreSuggestions(goal: string): ScoredSuggestion[] {
   const lower = goal.toLowerCase();
-  const candidates: ScoredSuggestion[] = [];
 
-  // Keyword buckets → weighted role/persona/framework triples.
-  const recipes: Array<{
-    keywords: string[];
-    suggestion: ScoredSuggestion;
-  }> = [
-    {
-      keywords: ["debug", "incident", "outage", "bug", "production", "rollback"],
-      suggestion: {
-        role_id: "technical-architect",
+  // Score each role
+  const scored: Array<{ role_id: string; score: number }> = ROLE_KEYWORDS.map(
+    (entry) => ({
+      role_id: entry.role_id,
+      score: scoreRoleKeywords(lower, entry),
+    }),
+  );
+
+  // Sort descending by score
+  scored.sort((a, b) => b.score - a.score);
+
+  // Filter to roles with score > 0 and take top 3
+  const matched = scored.filter((r) => r.score > 0).slice(0, 3);
+
+  if (matched.length === 0) {
+    // Generic fallback when no keyword matches
+    return [
+      {
+        role_id: "tech-lead",
         persona_id: "direct-pragmatist",
-        framework_id: "5-whys",
+        framework_id: "first-principles",
         rationale:
-          "Production incidents need a technical owner who can drive a root-cause loop without sentiment.",
+          "Generic ask defaults to a tech lead with a direct voice and a first-principles loop to surface assumptions.",
         rationale_fr:
-          "Les incidents en production réclament un·e architecte technique capable de mener une boucle de cause racine sans pathos.",
-        fit_score: 92,
+          "Demande générique : par défaut, un lead technique direct avec une boucle premiers principes pour révéler les hypothèses.",
+        fit_score: 70,
       },
-    },
-    {
-      keywords: ["debug", "incident", "outage", "bug", "production", "rollback"],
-      suggestion: {
-        role_id: "qa-engineer",
-        persona_id: "precise-analyst",
-        framework_id: "cynefin",
-        rationale:
-          "QA precision plus a Cynefin classification keeps the team out of premature fixes when the situation is complex or chaotic.",
-        rationale_fr:
-          "La précision QA et un classement Cynefin évitent les correctifs prématurés quand la situation est complexe ou chaotique.",
-        fit_score: 85,
-      },
-    },
-    {
-      keywords: ["strategy", "roadmap", "market", "competitive", "positioning"],
-      suggestion: {
-        role_id: "business-strategist",
-        persona_id: "concise-executive",
-        framework_id: "swot",
-        rationale:
-          "Strategic asks land best with an executive-concise voice and a SWOT scaffold for evidence.",
-        rationale_fr:
-          "Les demandes stratégiques passent mieux avec une voix exécutive concise et un cadre SWOT comme support de preuves.",
-        fit_score: 88,
-      },
-    },
-    {
-      keywords: ["coach", "leadership", "feedback", "team morale"],
-      suggestion: {
-        role_id: "executive-coach",
-        persona_id: "warm-mentor",
-        framework_id: "cynefin",
-        rationale:
-          "Coaching contexts call for a warm mentor voice and a sense-making framework, not a checklist.",
-        rationale_fr:
-          "Les contextes de coaching appellent une voix de mentor bienveillant et un cadre de sense-making, pas une checklist.",
-        fit_score: 90,
-      },
-    },
-    {
-      keywords: ["copy", "headline", "campaign", "brand voice", "marketing"],
-      suggestion: {
-        role_id: "copywriter",
-        persona_id: "playful-creative",
-        framework_id: null,
-        rationale:
-          "Copy work benefits from a playful creative persona; an explicit framework would over-constrain ideation.",
-        rationale_fr:
-          "Le travail de copie gagne avec un persona créatif joueur ; un framework explicite contraindrait trop l'idéation.",
-        fit_score: 80,
-      },
-    },
-    {
-      keywords: ["research", "literature", "study", "evidence"],
-      suggestion: {
-        role_id: "researcher",
-        persona_id: "formal-academic",
-        framework_id: "mece",
-        rationale:
-          "Research outputs read better with a formal-academic voice structured by a MECE decomposition.",
-        rationale_fr:
-          "Les livrables de recherche se lisent mieux avec une voix formelle académique structurée par une décomposition MECE.",
-        fit_score: 86,
-      },
-    },
-    {
-      keywords: ["prioriti", "overload", "too many", "backlog", "decide between"],
-      suggestion: {
+      {
         role_id: "product-manager",
-        persona_id: "direct-pragmatist",
-        framework_id: "eisenhower",
-        rationale:
-          "When everything feels urgent, a PM with the Eisenhower matrix forces a single quadrant per task.",
-        rationale_fr:
-          "Quand tout semble urgent, un·e PM avec la matrice d'Eisenhower force un seul quadrant par tâche.",
-        fit_score: 87,
-      },
-    },
-    {
-      keywords: ["data", "analytic", "metric", "dashboard", "kpi"],
-      suggestion: {
-        role_id: "data-analyst",
-        persona_id: "precise-analyst",
-        framework_id: "pareto",
-        rationale:
-          "Data work pairs naturally with a precise-analyst voice and a Pareto lens to surface the vital few.",
-        rationale_fr:
-          "Le travail data se marie naturellement avec une voix d'analyste rigoureux et une lecture Pareto pour faire émerger l'essentiel.",
-        fit_score: 84,
-      },
-    },
-    {
-      keywords: ["operation", "process", "scale", "vendor", "sla"],
-      suggestion: {
-        role_id: "operations-manager",
         persona_id: "concise-executive",
-        framework_id: "raci",
+        framework_id: "okr",
         rationale:
-          "Operations questions resolve faster with a concise-executive voice and a RACI to remove ownership ambiguity.",
+          "Backup recommendation: product-manager + concise-executive + OKR aligns intent with measurable outcomes.",
         rationale_fr:
-          "Les questions opérationnelles se résolvent plus vite avec une voix exécutive concise et un RACI pour lever l'ambiguïté de responsabilité.",
-        fit_score: 83,
+          "Recommandation de secours : product-manager + exécutif concis + OKR aligne l'intention sur des résultats mesurables.",
+        fit_score: 65,
       },
-    },
-    {
-      keywords: ["new product", "innovate", "blank page", "ideate"],
-      suggestion: {
-        role_id: "creative-director",
-        persona_id: "playful-creative",
-        framework_id: "design-thinking",
-        rationale:
-          "Greenfield innovation work benefits from a creative direction lens and a Design Thinking loop.",
-        rationale_fr:
-          "Le travail d'innovation en page blanche gagne avec un regard de direction créative et une boucle Design Thinking.",
-        fit_score: 89,
-      },
-    },
-  ];
+    ];
+  }
 
-  for (const recipe of recipes) {
-    if (recipe.keywords.some((k) => lower.includes(k))) {
-      candidates.push(recipe.suggestion);
+  // Build suggestions from matched roles
+  const suggestions: ScoredSuggestion[] = matched.map((r) => {
+    const comp = ROLE_COMPOSITIONS[r.role_id];
+    if (!comp) {
+      // Defensive fallback for unknown role_id
+      return {
+        role_id: "tech-lead" as z.infer<typeof ROLE_ID>,
+        persona_id: "direct-pragmatist" as z.infer<typeof PERSONA_ID>,
+        framework_id: "first-principles" as z.infer<typeof FRAMEWORK_ID>,
+        rationale: "Matched role composition not found — defaulting to tech-lead.",
+        rationale_fr: "Composition du rôle introuvable — retour sur tech-lead.",
+        fit_score: 70,
+      };
+    }
+
+    // Normalize fit_score: scale keyword score into 0-100 range capped at base_score
+    // base_score is the max possible for this role when it wins cleanly
+    const normalizedScore = Math.min(comp.base_score, comp.base_score - 2 + Math.min(r.score * 2, 4));
+
+    return {
+      role_id: r.role_id as z.infer<typeof ROLE_ID>,
+      persona_id: comp.persona_id,
+      framework_id: comp.framework_id,
+      rationale: comp.rationale,
+      rationale_fr: comp.rationale_fr,
+      fit_score: normalizedScore,
+    };
+  });
+
+  // Ensure scores are monotonically non-increasing (already sorted by keyword score,
+  // but enforce in case of ties)
+  for (let i = 1; i < suggestions.length; i++) {
+    const prev = suggestions[i - 1];
+    const cur = suggestions[i];
+    if (prev && cur && cur.fit_score > prev.fit_score) {
+      suggestions[i] = { ...cur, fit_score: prev.fit_score };
     }
   }
 
-  // Always provide a sensible fallback if nothing matched.
-  if (candidates.length === 0) {
-    candidates.push({
-      role_id: "tech-lead",
-      persona_id: "direct-pragmatist",
-      framework_id: "first-principles",
-      rationale:
-        "Generic ask defaults to a tech lead with a direct voice and a first-principles loop to surface assumptions.",
-      rationale_fr:
-        "Demande générique : par défaut, un lead technique direct avec une boucle premiers principes pour révéler les hypothèses.",
-      fit_score: 70,
-    });
-    candidates.push({
-      role_id: "product-manager",
-      persona_id: "concise-executive",
-      framework_id: "okr",
-      rationale:
-        "Backup recommendation: product-manager + concise-executive + OKR aligns intent with measurable outcomes.",
-      rationale_fr:
-        "Recommandation de secours : product-manager + exécutif concis + OKR aligne l'intention sur des résultats mesurables.",
-      fit_score: 65,
-    });
-  }
-
-  // De-duplicate by role+persona+framework triple.
-  const seen = new Set<string>();
-  const unique = candidates.filter((c) => {
-    const key = `${c.role_id}|${c.persona_id}|${c.framework_id ?? "none"}`;
-    if (seen.has(key)) return false;
-    seen.add(key);
-    return true;
-  });
-
-  // Sort descending by fit_score, take top 3.
-  unique.sort((a, b) => b.fit_score - a.fit_score);
-  return unique.slice(0, 3);
+  return suggestions;
 }
 
 export const tool = {

--- a/tests/unit/suggest_composition-keyword-matching.test.ts
+++ b/tests/unit/suggest_composition-keyword-matching.test.ts
@@ -1,0 +1,110 @@
+/**
+ * suggest_composition-keyword-matching.test.ts
+ * Tests for GitHub issue #3 fix: keyword index FR+EN per role.
+ * "Rédiger des posts LinkedIn" must return copywriter, not tech-lead fallback.
+ */
+import { describe, it, expect } from "vitest";
+import { tool } from "../../src/tools/suggest_composition.js";
+
+describe("suggest_composition — keyword matching (Issue #3 fix)", () => {
+  it("FR: 'Rédiger des posts LinkedIn pour X' → top match copywriter", async () => {
+    const out = await tool.handler({
+      goal: "Rédiger des posts LinkedIn pour promouvoir notre nouvelle offre de service.",
+      locale: "fr",
+    });
+    expect(out.suggestions.length).toBeGreaterThan(0);
+    expect(out.suggestions[0]?.role_id).toBe("copywriter");
+  });
+
+  it("EN: 'Write LinkedIn posts and tweets for product launch' → top match copywriter", async () => {
+    const out = await tool.handler({
+      goal: "Write LinkedIn posts and tweets for our product launch campaign this quarter.",
+      locale: "en",
+    });
+    expect(out.suggestions.length).toBeGreaterThan(0);
+    expect(out.suggestions[0]?.role_id).toBe("copywriter");
+  });
+
+  it("EN: 'Build a CI/CD pipeline and deploy infra' → top match tech-lead or senior-developer", async () => {
+    const out = await tool.handler({
+      goal: "Build a CI/CD pipeline to deploy our infrastructure automatically on every merge.",
+      locale: "en",
+    });
+    expect(out.suggestions.length).toBeGreaterThan(0);
+    const topRole = out.suggestions[0]?.role_id;
+    expect(["tech-lead", "senior-developer", "technical-architect"]).toContain(topRole);
+  });
+
+  it("EN: 'Run a market analysis on competitors' → top match business-strategist or data-analyst", async () => {
+    const out = await tool.handler({
+      goal: "Run a market analysis on our main competitors and assess our positioning strategy.",
+      locale: "en",
+    });
+    expect(out.suggestions.length).toBeGreaterThan(0);
+    const topRole = out.suggestions[0]?.role_id;
+    expect(["business-strategist", "data-analyst", "researcher"]).toContain(topRole);
+  });
+
+  it("FR: 'Auditer notre stratégie produit' → top match product-manager or business-strategist", async () => {
+    const out = await tool.handler({
+      goal: "Auditer notre stratégie produit et proposer une nouvelle roadmap pour Q3 2026.",
+      locale: "fr",
+    });
+    expect(out.suggestions.length).toBeGreaterThan(0);
+    const topRole = out.suggestions[0]?.role_id;
+    expect(["product-manager", "business-strategist"]).toContain(topRole);
+  });
+
+  it("Ambiguous/empty-signal goal → fallback tech-lead (generic)", async () => {
+    const out = await tool.handler({
+      goal: "I want a helpful assistant but I am not sure what for exactly yet.",
+      locale: "en",
+    });
+    expect(out.suggestions.length).toBeGreaterThan(0);
+    // Fallback case: tech-lead should be top suggestion
+    expect(out.suggestions[0]?.role_id).toBe("tech-lead");
+    // Rationale should exist
+    expect(out.suggestions[0]?.rationale.length).toBeGreaterThan(0);
+    expect(out.suggestions[0]?.rationale_fr.length).toBeGreaterThan(0);
+  });
+
+  it("fit_scores are monotonically non-increasing", async () => {
+    const out = await tool.handler({
+      goal: "Rédiger des posts LinkedIn pour promouvoir notre nouvelle offre de service.",
+      locale: "fr",
+    });
+    const scores = out.suggestions.map((s) => s.fit_score);
+    for (let i = 1; i < scores.length; i++) {
+      const prev = scores[i - 1];
+      const cur = scores[i];
+      expect(prev !== undefined && cur !== undefined && prev >= cur).toBe(true);
+    }
+  });
+
+  it("FR: newsletter rédaction → copywriter", async () => {
+    const out = await tool.handler({
+      goal: "Rédiger une newsletter mensuelle pour fidéliser notre base clients existante.",
+      locale: "fr",
+    });
+    expect(out.suggestions.length).toBeGreaterThan(0);
+    expect(out.suggestions[0]?.role_id).toBe("copywriter");
+  });
+
+  it("EN: data analysis + dashboard → data-analyst", async () => {
+    const out = await tool.handler({
+      goal: "Analyze our sales data and create a KPI dashboard to track quarterly metrics.",
+      locale: "en",
+    });
+    expect(out.suggestions.length).toBeGreaterThan(0);
+    expect(out.suggestions[0]?.role_id).toBe("data-analyst");
+  });
+
+  it("EN: coaching leadership feedback → executive-coach", async () => {
+    const out = await tool.handler({
+      goal: "Coach our senior managers on leadership and help them deliver meaningful feedback to their teams.",
+      locale: "en",
+    });
+    expect(out.suggestions.length).toBeGreaterThan(0);
+    expect(out.suggestions[0]?.role_id).toBe("executive-coach");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #3 — `suggest_composition` was returning generic `tech-lead + direct-pragmatist + first-principles` even when goal contained explicit role-specific keywords (e.g. \"Rédiger des posts LinkedIn\" → should match `copywriter`).

### Root Cause
The previous implementation used a flat list of recipe buckets where each recipe checked a hardcoded keyword array. The `copywriter` bucket only checked `["copy", "headline", "campaign", "brand voice", "marketing"]` — missing all French terms and common English terms like "write", "post", "LinkedIn", "tweet", "draft", etc.

### Fix
- Added `src/data/role-keywords.ts`: comprehensive keyword index FR+EN per role (12 roles, 150+ keywords). Multi-word phrases scored +3, single tokens +1.
- Rewrote `scoreSuggestions()` in `suggest_composition.ts`: score ALL roles against goal, pick top 3 by keyword score. Generic fallback (`tech-lead`) triggers only when ALL roles score 0.
- Added `ROLE_COMPOSITIONS` table mapping `role_id → {persona_id, framework_id, rationale EN+FR, base_score}` — keeps composition logic clean and auditable.

### Tests
- 10 new unit tests: `tests/unit/suggest_composition-keyword-matching.test.ts`
- 5 new evals (#16–#20): `evals/evals.json`
- All green: 45/45 unit tests, 20/20 evals, smoke PASS, build clean

### Hard-gate acceptance criteria
- ✓ "Rédiger des posts LinkedIn pour X" → `copywriter` top 1
- ✓ "Build a CI/CD pipeline" → `tech-lead`/`senior-developer`/`technical-architect` top 1
- ✓ "Run a market analysis" → `business-strategist`/`data-analyst` top 1
- ✓ Generic fallback only when no keyword match

### Leak audit
- 0 hits on pre-publish leak pattern scan

Orchestrator: Gamma — VantageOS Team | 2026-04-26